### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: Golang CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/tolyo/open-outcry/security/code-scanning/2](https://github.com/tolyo/open-outcry/security/code-scanning/2)

In general, the fix is to explicitly declare a restrictive `permissions` block so that the `GITHUB_TOKEN` used by this workflow does not inherit broad repository defaults. Since this CI job only needs to read repository contents (for checkout and building/testing the Go code) and does not modify repository state, we can safely set `contents: read` and omit any write scopes.

The single best fix here is to add a `permissions` block at the workflow root (top level, alongside `name` and `on`). That ensures all jobs in this workflow, including `build`, use the same minimal read-only permissions unless overridden. Concretely, in `.github/workflows/ci.yml`, between the `name: Golang CI` and the `on:` declaration, insert:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are required, as this is purely a YAML configuration change to the GitHub Actions workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
